### PR TITLE
fix: check props before access

### DIFF
--- a/src/angular/ng-ripple.directive.ts
+++ b/src/angular/ng-ripple.directive.ts
@@ -57,8 +57,8 @@ export class NativeRippleDirective implements OnInit, OnChanges, OnDestroy {
         }
     }
     ngOnChanges(changes: SimpleChanges) {
-        if (changes.ripple.currentValue !== changes.ripple.previousValue ||
-            changes.rippleColor.currentValue !== changes.rippleColor.currentValue) {
+        if ((changes.ripple && changes.ripple.currentValue !== changes.ripple.previousValue) ||
+            (changes.rippleColor && changes.rippleColor.currentValue !== changes.rippleColor.currentValue)) {
             this.applyOrRemoveRipple();
         }
     }


### PR DESCRIPTION

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently setting the rippleColor with an expression causes issues:
`  rippleColor="{{(item.someProp === true ? '#000000' :'transparent')}}"
`

The error that occurs when using this in ListViews:
`ERROR TypeError: Cannot read property 'currentValue' of undefined`


## What is the new behavior?
We now check if the properties in ngOnChanges are there or not, before accessing them. 
